### PR TITLE
feat: add video duration-based pricing via HTML5 File API

### DIFF
--- a/src/add-ons/super-forms-calculator/assets/js/frontend/calculator.js
+++ b/src/add-ons/super-forms-calculator/assets/js/frontend/calculator.js
@@ -595,6 +595,32 @@
 				}
 			}
 
+			// @since 6.5.0 - Check if file upload field - supports {fieldname;duration} for total video duration
+			if (parent.classList.contains( 'super-file' )) {
+				text_field = false;
+				if (value_n === 'duration') {
+					var uploadFormId = 0,
+						uploadFormInput = form.querySelector( 'input[name="hidden_form_id"]' );
+					if (uploadFormInput) {
+						uploadFormId = uploadFormInput.value;
+					}
+					sum = 0;
+					if (typeof SUPER.files !== 'undefined' &&
+						typeof SUPER.files[uploadFormId] !== 'undefined' &&
+						typeof SUPER.files[uploadFormId][name] !== 'undefined') {
+						var fileList = SUPER.files[uploadFormId][name];
+						for (var fli = 0; fli < fileList.length; fli++) {
+							if (fileList[fli] && typeof fileList[fli]['duration'] !== 'undefined') {
+								sum += parseFloat( fileList[fli]['duration'] );
+							}
+						}
+					}
+					value = sum;
+				} else {
+					value = 0;
+				}
+			}
+
 			// Check if text or textarea field
 			if (text_field === true) {
 				value = (element.value) ? parseFloat( element.value ) : 0;

--- a/src/assets/js/common.js
+++ b/src/assets/js/common.js
@@ -1931,6 +1931,19 @@ function SUPERreCaptcha(){
                             var totalFiles = SUPER.files[formId][fieldName].length;
                             SUPER.files[formId][fieldName][totalFiles] = file;
                             SUPER.files[formId][fieldName][totalFiles]['url'] = src; // blob
+                            // @since 6.5.0 - For video files, read duration via HTML5 File API before upload
+                            if(file.type && file.type.indexOf("video/") === 0){
+                                (function(capturedFormId, capturedFieldName, capturedIndex, capturedField, capturedForm){
+                                    var videoEl = document.createElement('video');
+                                    videoEl.preload = 'metadata';
+                                    videoEl.onloadedmetadata = function(){
+                                        URL.revokeObjectURL(videoEl.src);
+                                        SUPER.files[capturedFormId][capturedFieldName][capturedIndex]['duration'] = videoEl.duration;
+                                        SUPER.after_field_change_blur_hook({el: capturedField, form: capturedForm});
+                                    };
+                                    videoEl.src = URL.createObjectURL(file);
+                                })(formId, fieldName, totalFiles, field, form);
+                            }
                             var html = SUPER.get_single_uploaded_file_html(true, false, file.name, file.type, src);
                             data.context.data(data).attr('data-name',file.name).attr('title',file.name).attr('data-type',file.type).html(html);
                             data.context.data('file-size',file.size);


### PR DESCRIPTION
## Description

Allows calculator fields to use `{fieldname;duration}` syntax to sum total video duration (seconds) of uploaded files before submission. Uses HTML5 File API with a hidden `<video>` element to read metadata without uploading.

Closes #104

## Target Branch
- [x] `master`

## Super Forms Version
**Targets version:** v6.4.201

## User Population Affected
- [x] Add-on users only — add-on name: Calculator / File Upload

## Type of Change
- [x] New feature (non-breaking)

## Backward Compatibility Checklist
- [x] No `super_*` hook or filter name was renamed or removed
- [x] No `[super_form]` shortcode attribute was removed or renamed
- [x] No Action Scheduler hook name was changed

## For AI-Generated PRs
**Source issue:** #104
**Implementation confidence:** uncertain
**Files modified:** src/assets/js/common.js
**New hooks added (if any):** none
**Migration required:** no