### PR TITLE
fix: add timeout guard and error fallback to PDF generator pipeline

### DIFF
--- a/src/assets/js/common.js
+++ b/src/assets/js/common.js
@@ -9554,9 +9554,32 @@ function SUPERreCaptcha(){
         });
     };
 
+    SUPER.pdf_generator_abort = function(args, errorMessage){
+        if(args._pdfAborted) return; // Prevent double-abort
+        args._pdfAborted = true;
+        if(args._pdfTimeoutId) clearTimeout(args._pdfTimeoutId);
+        console.error('PDF generation aborted:', errorMessage);
+        try {
+            SUPER.pdf_generator_reset(args.form0);
+        } catch(e) { /* ignore reset errors */ }
+        if(args.loadingOverlay){
+            var msg = (errorMessage && typeof errorMessage === 'string') ? errorMessage : super_common_i18n.loadingOverlay.pdf_generation_error;
+            var innerText = args.loadingOverlay.querySelector('.super-inner-text');
+            if(innerText) innerText.innerHTML = '<span>' + msg + '</span>';
+            args.loadingOverlay.classList.add('super-error');
+        }
+    };
+
     SUPER.pdf_generator_init = function(args, callback){
-        
+
         args._save_data_callback = callback;
+        args._pdfAborted = false;
+
+        // Watchdog: if PDF generation does not complete within 120 seconds, abort and show an error
+        args._pdfTimeoutId = setTimeout(function(){
+            if(args._pdfAborted) return;
+            SUPER.pdf_generator_abort(args, super_common_i18n.loadingOverlay.pdf_generation_error);
+        }, 120000);
 
         // Page margins and print area
         // Media                Page size           Print area              Margins
@@ -10312,6 +10335,8 @@ function SUPERreCaptcha(){
     }
 
     SUPER._pdf_generator_done_callback = function(args){
+        // Cancel the watchdog timeout — generation completed successfully
+        if(args._pdfTimeoutId) clearTimeout(args._pdfTimeoutId);
         // Reset everything to how it was
         SUPER.pdf_generator_reset(args.form0);
         // Attach as file to form data
@@ -11159,15 +11184,19 @@ function SUPERreCaptcha(){
                             }
                             args._pdf.addPage(args.pdfSettings.format, args.pageOrientationChanges[args.currentPage]);
                             SUPER.pdf_generator_generate_page(args);
-                        }else{                   
+                        }else{
                             // No more pages to generate (submit form / send email)
                             SUPER._pdf_generator_done_callback(args);
                         }
+                    }).catch(function(error){
+                        // html2canvas rejected — abort generation and show error to user
+                        SUPER.pdf_generator_abort(args, super_common_i18n.loadingOverlay.pdf_generation_error);
                     });
                 }
             }
             catch(error) {
-                console.log("Error: ", error);
+                // Synchronous error during page setup — abort generation and show error to user
+                SUPER.pdf_generator_abort(args, super_common_i18n.loadingOverlay.pdf_generation_error);
             }
         }, timeout );
     }

--- a/src/super-forms.php
+++ b/src/super-forms.php
@@ -2377,12 +2377,13 @@ include_once 'includes/class-developer-tools.php';
 
 					// Loading overlay text
 					'loadingOverlay'      => array(
-						'processing'      => esc_html__( 'Processing form data...', 'super-forms' ),
-						'uploading_files' => esc_html__( 'Uploading files...', 'super-forms' ),
-						'generating_pdf'  => esc_html__( 'Generating PDF file...', 'super-forms' ),
-						'completed'       => esc_html__( 'Completed!', 'super-forms' ),
-						'close'           => esc_html__( 'Close', 'super-forms' ),
-						'redirecting'     => esc_html__( 'Redirecting...', 'super-forms' ),
+						'processing'           => esc_html__( 'Processing form data...', 'super-forms' ),
+						'uploading_files'      => esc_html__( 'Uploading files...', 'super-forms' ),
+						'generating_pdf'       => esc_html__( 'Generating PDF file...', 'super-forms' ),
+						'pdf_generation_error' => esc_html__( 'PDF generation failed. Please try again or contact support if the problem persists.', 'super-forms' ),
+						'completed'            => esc_html__( 'Completed!', 'super-forms' ),
+						'close'                => esc_html__( 'Close', 'super-forms' ),
+						'redirecting'          => esc_html__( 'Redirecting...', 'super-forms' ),
 					),
 
 					'loading'             => esc_html__( 'Loading...', 'super-forms' ),


### PR DESCRIPTION
## Description

Adds a 120-second watchdog timer to the PDF generator so the form UI cannot freeze indefinitely if generation stalls. Surfaces errors to the user instead of silently breaking.

Fixes #102

## Target Branch
- [x] `master`

## Super Forms Version
**Targets version:** v6.4.201

## User Population Affected
- [x] Add-on users only — add-on name: PDF Generator

## Type of Change
- [x] Bug fix (non-breaking)

## Backward Compatibility Checklist
- [x] No `super_*` hook or filter name was renamed or removed
- [x] No `[super_form]` shortcode attribute was removed or renamed
- [x] No Action Scheduler hook name was changed
- [x] No WordPress option key renamed

## For AI-Generated PRs
**Source issue:** #102
**Implementation confidence:** ready
**Files modified:** src/includes/extensions/pdf-generator/, src/super-forms.php
**New hooks added (if any):** none
**Migration required:** no