### PR TITLE
docs: changelog entry for v6.3.313 stable backport (WP 7.0 compat)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@
 
 - [PDF Generator Add-on](https://docs.super-forms.com/features/integrations/pdf-generator)
 
+## May 31, 2026 - Version 6.3.313
+
+- **Improved:** Compatibility with WordPress 7.0
+
 ## Nov 18, 2025 - Version 6.4.200
 
 - **Added:** WP-Cron fallback system for reliable background processing — Action Scheduler

--- a/gitbook-docs/changelog.md
+++ b/gitbook-docs/changelog.md
@@ -11,6 +11,10 @@ description: New features, improvements and bug fixes.
 * [Listings Add-on](features/integrations/listings.md)
 * [PDF Generator Add-on](features/integrations/pdf-generator.md)
 
+### May 31, 2026 - Version 6.3.313
+
+* **Improved:** Compatibility with WordPress 7.0
+
 ### Apr 24, 2024 - Version 6.4.003-beta
 
 * **Added:** New \[Stripe] tab to configure Stripe checkout, allowing for one time payments and recurring payments.


### PR DESCRIPTION
Adds a single user-facing bullet to `docs/changelog.md` and `gitbook-docs/changelog.md` for the v6.3.313 stable maintenance release.

The v6.3.313 release ships the bundled `super-forms.zip` with:
- Plugin header: Version 6.3.313, Tested up to: 7.0
- `super-forms-csv-attachment.php`: replaced PHP 8.2+ deprecated `${var}` interpolation with `{$var}` (caught by runtime smoke test on `wp.stable`; missed by the initial grep audit)

The release itself does NOT live on master — it ships as the bundled `super-forms.zip` on `f4d.nl:packages/`. This PR only updates the public docs site (`docs.super-forms.com`) to reflect the new stable channel release.

See cc-inbox `AGENTS.md` "### Maintenance backport procedure" for the full workflow.

Companion artifacts:
- `release/6.3.x` branch (orphan, 2 commits): v6.3.312 baseline + v6.3.313 backport
- `v6.3.313` tag on the same
- `f4d.nl:@super-forms-updates/packages/super-forms.zip` now serves v6.3.313 (verified at origin via local curl)
- `MyCustomServer.php` `tested=7.0`, plus new `Cache-Control: no-cache` headers so future releases don't suffer SiteGround edge-cache propagation lag