### PR TITLE
Align CI guardrails with branch model

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,10 @@ Fixes # (issue)
 
 ## Target Branch
 
-- [ ] `master` (stable — bug fixes, improvements, features for current users)
-- [ ] `next/v7` (unreleased rewrite — Automations / React admin / Themes only)
+- [ ] `stable` (current v6 stable line — bug fixes and backward-compatible improvements)
+- [ ] `beta` (v6 next-minor release candidate — new v6 features)
+- [ ] `alpha` (v7 major-work integration — internal-only)
+- [ ] v6.3 LTS branch (security / critical bugfix backports only)
 
 ## Super Forms Version
 
@@ -43,7 +45,7 @@ Fixes # (issue)
 - [ ] JSHint passes (`npm run jshint`) — or no JS was modified
 - [ ] Production build succeeds (`npm run prod`) — or no build files were modified
 
-## Testing
+## Verification
 
 - [ ] Tested locally against WordPress 6.4+
 - [ ] Tested the specific scenario from the linked issue

--- a/.github/scripts/leak-scan.cjs
+++ b/.github/scripts/leak-scan.cjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Auto-generated prohibited-language scanner runtime.
+ * DO NOT EDIT MANUALLY. Regenerate from the private operator-side scanner source.
+ *
+ * Generated: 2026-06-10T03:07:40.872Z
+ * Source of truth: private operator-side prohibited-language pattern catalogue.
+ *
+ * What this script does:
+ *   Scans a single file's contents for private infrastructure / process /
+ *   engineering-narration tokens that must never leak into public release
+ *   bodies, customer-facing prose, or public source-tree files. Exits 1 with
+ *   a structured failure message when any BLOCKER hit is found. WARN-severity
+ *   hits are not surfaced (matching the fail-closed scanner contract).
+ *
+ * CLI:
+ *   node leak-scan.cjs <file> [--audience body|release_body|repo_file]
+ *
+ *   --audience defaults to 'body' (the most permissive non-release surface).
+ *   Pass 'release_body' for GitHub Release body content; 'repo_file' for
+ *   tracked-file content checks.
+ */
+'use strict';
+
+const LEAK_PATTERNS = [
+	{ pattern: /f4d\.nl/i, category: "infra", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /@super-forms-updates/i, category: "infra", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /Wpup/i, category: "infra", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /MyCustomServer/i, category: "infra", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /wp\.(stable|beta|alpha|dev)\.super-forms\.com/i, category: "infra", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /release\/6\.3\.x/i, category: "internal_branch", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /release\/6\.4\.x/i, category: "internal_branch", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /lts\/6\.3\.x/i, category: "internal_branch", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /gitbook-docs/i, category: "internal_path", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /sf-scripts/i, category: "cc_inbox_cli", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /cc-inbox/i, category: "cc_inbox_brand", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /AGENTS\.md/i, category: "agent_vocabulary", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /^(?:#+\s*)?\*{0,2}Source commit/im, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /^(?:#+\s*)?\*{0,2}Provenance/im, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body"] },
+	{ pattern: /^(?:#+\s*)?\*{0,2}Customer impact/im, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /^(?:#+\s*)?\*{0,2}Channel:/im, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /^(?:#+\s*)?\*{0,2}Customer ZIP:/im, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /^(?:#+\s*)?\*{0,2}Source branch:/im, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /byte-for-byte/i, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /md5 hash/i, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /sha256/i, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /backport from/i, category: "engineering_narration", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\/termux-home\//i, category: "internal_path", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bDieske\b/i, category: "agent_vocabulary", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bRens-(?:gated|decides|approves|commissions)\b/i, category: "gated_action", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bstore\/(?:repos|gmail|zendesk)\//i, category: "internal_path", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bstore\/kb\//i, category: "internal_path", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /(?:^|[\s"'`(])\.omp\//, category: "internal_path", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bfeature-verify-cli\b/i, category: "cc_inbox_cli", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bsource:workspace\b/i, category: "cc_inbox_cli", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bprocess-pending-issues\b/i, category: "cc_inbox_cli", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bcapabilities\.md\b/i, category: "internal_path", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bbun run review\b/i, category: "cc_inbox_cli", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bbun src\/scripts\//i, category: "cc_inbox_cli", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bpublish-release\.ts\b/i, category: "release_process", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bcc[_]inbox\b|\bccinbox\b/i, category: "cc_inbox_brand", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bdoctrine\b/i, category: "agent_vocabulary", severity: "WARN", audience: ["release_body"], allowlistPhrases: ["doctrine/instantiator"] },
+	{ pattern: /\blocal:\/\/[A-Z0-9_]+\.md\b/, category: "internal_url", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\b(?:agent|memory|artifact|jobs|skill|rule|pi):\/\//i, category: "internal_url", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\.planning\//i, category: "internal_path", severity: "WARN", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bSF_[A-Z_]+_PLAN\b/, category: "agent_vocabulary", severity: "WARN", audience: ["release_body","body","repo_file"] },
+	{ pattern: /--dry-run\s+--show-request\b/i, category: "release_process", severity: "WARN", audience: ["release_body","body","repo_file"] },
+	{ pattern: /operator[\s-]password\b/i, category: "gated_action", severity: "WARN", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\b[0-9a-f]{16}\b/i, category: "customer_identifier", severity: "BLOCKER", audience: ["release_body","body","repo_file"] },
+	{ pattern: /\bticket\s*#?\s*\d{4,7}\b/i, category: "customer_identifier", severity: "WARN", audience: ["release_body","body","repo_file"] },
+];
+
+const REPO_FILE_PATH_ALLOWLIST = [
+	/^\.github\/workflows\/claude.*\.ya?ml$/i,
+	/^\.github\/scripts\/leak-scan\.cjs$/i,
+	/^\.mcp\/README\.md$/i,
+	/^src\/react\/admin\/pages\/settings\/AiProviderPanel\.tsx$/,
+	/^src\/includes\/automations\/actions\/class-action-ai-completion\.php$/,
+	/^CLAUDE\.md$/,
+	/^AGENTS\.md$/,
+	/^docs\/CLAUDE\.(?:php|javascript|ui)\.md$/,
+];
+
+const WORD_BOUNDARY_TOKENS = ["v7","master","v6.4.200","v6.4.201","v6.4.x"];
+const LITERAL_SUBSTRINGS = ["[v7 alpha]","[scaffold only]","[on master, unshipped]","[on stable, unshipped]","[not present anywhere]","[in public stable]","[in public beta only]","next/v7","the rewrite","react rewrite","react version"];
+
+function escapeRegExp(s) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const WORD_BOUNDARY_REGEXES = WORD_BOUNDARY_TOKENS.map((token) => ({
+	token,
+	regex: new RegExp(`\\b${escapeRegExp(token)}\\b`, 'i'),
+}));
+
+function scanForAudience(body, audience) {
+	const hits = new Set();
+	const lower = body.toLowerCase();
+	for (const entry of LEAK_PATTERNS) {
+		if (entry.severity !== 'BLOCKER') continue;
+		if (!entry.audience.includes(audience)) continue;
+		if (!entry.pattern.test(body)) continue;
+		if (entry.allowlistPhrases && entry.allowlistPhrases.some((p) => lower.includes(p.toLowerCase()))) continue;
+		hits.add(entry.pattern.toString());
+	}
+	return Array.from(hits);
+}
+
+function findProhibitedLanguageInBody(body) {
+	const hits = new Set(scanForAudience(body, 'body'));
+	for (const { token, regex } of WORD_BOUNDARY_REGEXES) {
+		if (regex.test(body)) hits.add(token);
+	}
+	const lower = body.toLowerCase();
+	for (const phrase of LITERAL_SUBSTRINGS) {
+		if (lower.includes(phrase.toLowerCase())) hits.add(phrase);
+	}
+	return Array.from(hits);
+}
+
+function findProhibitedLanguageInReleaseBody(body) {
+	return scanForAudience(body, 'release_body');
+}
+
+function findProhibitedLanguageInRepoFile(relativePath, content, privacy) {
+	if (privacy === 'private' || privacy === 'internal') return [];
+	for (const rx of REPO_FILE_PATH_ALLOWLIST) {
+		if (rx.test(relativePath)) return [];
+	}
+	return scanForAudience(content, 'repo_file');
+}
+
+// ─── CLI entry ─────────────────────────────────────────────────────────────
+
+function main() {
+	const args = process.argv.slice(2);
+	let file;
+	let audience = 'body';
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i];
+		const next = args[i + 1];
+		if (a === '--audience') {
+			if (!next || !['body', 'release_body', 'repo_file'].includes(next)) {
+				console.error('--audience must be one of: body, release_body, repo_file');
+				process.exit(2);
+			}
+			audience = next;
+			i++;
+		} else if (a === '--help' || a === '-h') {
+			console.log('Usage: node leak-scan.cjs <file> [--audience body|release_body|repo_file]');
+			process.exit(0);
+		} else if (a.startsWith('--')) {
+			console.error(`unknown flag: ${a}`);
+			process.exit(2);
+		} else {
+			file = a;
+		}
+	}
+	if (!file) {
+		console.error('usage: node leak-scan.cjs <file> [--audience body|release_body|repo_file]');
+		process.exit(2);
+	}
+	const fs = require('node:fs');
+	const path = require('node:path');
+	let content;
+	try {
+		content = fs.readFileSync(file, 'utf8');
+	} catch (err) {
+		console.error(`[leak-scan] cannot read ${file}: ${err.message}`);
+		process.exit(2);
+	}
+	let hits;
+	if (audience === 'release_body') {
+		hits = findProhibitedLanguageInReleaseBody(content);
+	} else if (audience === 'repo_file') {
+		hits = findProhibitedLanguageInRepoFile(path.relative(process.cwd(), file), content);
+	} else {
+		hits = findProhibitedLanguageInBody(content);
+	}
+	if (hits.length > 0) {
+		console.error(`[leak-scan] ${file} (audience=${audience}) contains prohibited language:`);
+		for (const h of hits) console.error(`  - ${h}`);
+		process.exit(1);
+	}
+	console.log(`[leak-scan] ${file} (audience=${audience}) clean`);
+	process.exit(0);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+	LEAK_PATTERNS,
+	findProhibitedLanguageInBody,
+	findProhibitedLanguageInReleaseBody,
+	findProhibitedLanguageInRepoFile,
+};

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,13 +1,21 @@
 name: Claude PR Review
 
+run-name: "Claude PR Review · #${{ github.event.pull_request.number }} · ${{ github.event.pull_request.title }}"
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
+    # Do not review Claude's own PRs - it describes its work in the PR body.
     if: github.event.pull_request.user.login != 'claude[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -19,13 +27,47 @@ jobs:
           fetch-depth: 1
       - name: Review PR
         # renovate: datasource=github-releases depName=anthropics/claude-code-action
-        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262
+        uses: anthropics/claude-code-action@e34df8781c2370c1c9d3b83ae47286a7ae2d1ea6 # v1.0.135
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
           plugins: |
             pr-review-toolkit
-          claude_args: "--max-turns 10 --allowedTools Read,Bash"
+          claude_args: |
+            --max-turns 5
+            --allowedTools Read,Bash
+            --append-system-prompt "You are reviewing a pull request to the Super Forms WordPress plugin.
+
+            **Branch Awareness**
+            - `master`: production-stable. High bar — changes are live for paying customers.
+            - `next/v7`: unreleased React rewrite. Do not apply master/v6 rules to next/v7 PRs.
+
+            **Backward Compatibility — BLOCKER if violated**
+            1. `apply_filters('super_*')` and `do_action('super_*')` hook names must not change.
+            2. `[super_form]` shortcode attributes must not be removed or renamed.
+            3. Contact entry retrieval must use `SUPER_Data_Access::get_entry_data()`, not `get_post_meta()`.
+            4. Action Scheduler hook names must not change after first release.
+            5. Public add-on class methods must not be removed without a deprecation path.
+            6. WordPress option keys (`super_*`) must not be renamed without an upgrade migration.
+
+            **Security — BLOCKER if missing**
+            WordPress nonces on AJAX (`check_ajax_referer`), capability checks (`current_user_can`), input sanitization (`sanitize_*`), output escaping (`esc_*`) — any omission is BLOCKER.
+
+            **Data Access — BLOCKER**
+            Any new `get_post_meta()` call for contact entry data without using `SUPER_Data_Access` = BLOCKER.
+
+            **CI Verification**
+            Check whether the verify workflow passed for this PR with: gh pr checks ${{ github.event.pull_request.number }}
+            If verify failed or has not run: state this as [BLOCKER] before reviewing logic.
+
+            **Severity Taxonomy**
+            Use exactly one per comment:
+            - [BLOCKER] — Breaks production, exposes security hole, or violates a compat rule.
+            - [MAJOR] — Logic error or significant quality issue.
+            - [MINOR] — Style or non-critical improvement.
+            - [INFO] — Observation, no action required.
+
+            End with a one-sentence verdict and: APPROVE, REQUEST_CHANGES, or COMMENT."
           prompt: |
             /review-pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,8 +40,10 @@ jobs:
             --append-system-prompt "You are reviewing a pull request to the Super Forms WordPress plugin.
 
             **Branch Awareness**
-            - `master`: production-stable. High bar — changes are live for paying customers.
-            - `next/v7`: unreleased React rewrite. Do not apply master/v6 rules to next/v7 PRs.
+            - `stable`: current v6 stable line. Highest bar — changes ship to paying customers via auto-update.
+            - `beta`: v6 next-minor release candidate. Receives features; soaked on opt-in customers before promotion to stable.
+            - `alpha`: v7 major-work integration. Unreleased. Different conventions; do not apply v6 stable rules to alpha PRs.
+            - `lts/6.3.x`: v6.3 LTS line. Security + critical bugfix backports only.
 
             **Backward Compatibility — BLOCKER if violated**
             1. `apply_filters('super_*')` and `do_action('super_*')` hook names must not change.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,14 +57,14 @@ jobs:
 
             **Permitted Actions**
             - Read files, search the codebase (grep, find, read)
-            - Create branches from `master` (naming: `claude/issue-{number}-{YYYYMMDD}`)
+            - Create branches from `origin/<target_branch>` (`stable` by default; `beta`, `alpha`, or `lts/6.3.x` only when explicitly requested)
             - Commit to your own branch and push
-            - Open PRs targeting `master`
+            - Open PRs targeting the channel specified in `target_branch` (default `stable`)
             - Comment on issues and PRs with research findings
 
             **Prohibited Actions**
-            - Pushing directly to `master`, `next/v7`, `dev`, `dev2`, or branches you didn't create
-            - Opening PRs targeting `next/v7`
+            - Pushing directly to `stable`, `beta`, `alpha`, `lts/6.3.x`, or branches you didn't create
+            - Opening PRs against a branch other than the issue's `target_branch`
             - Renaming or removing any `super_*` hook or filter
             - Using `get_post_meta()` for contact entry data (use `SUPER_Data_Access::get_entry_data()`)
             - Renaming Action Scheduler hook names
@@ -79,12 +79,12 @@ jobs:
             6. New hooks/attributes/option keys documented in code comment or PR body
 
             **Branch Rules**
-            - Always branch from latest `origin/master`
+            - Always branch from latest `origin/<target_branch>`
             - Naming: `claude/issue-{number}-{YYYYMMDD}`
-            - All PRs target `master`
+            - All PRs target the channel specified in `target_branch` (default `stable`; `beta` for next-minor features; `alpha` for v7 work; `lts/6.3.x` for v6.3 LTS-only bugfixes)
 
-            **Handling next/v7 Requests**
-            If asked to implement Automations, Themes, MCP server, React admin, or shadcn/Tailwind/Vite UI features: explain these belong to `next/v7` (unreleased), offer a master-compatible alternative if one exists, otherwise decline with explanation. Never silently attempt to implement next/v7 features against master.
+            **Handling alpha-channel Requests**
+            If asked to implement Automations, Themes, MCP server, React admin, or shadcn/Tailwind/Vite UI features: these belong to `alpha` (unreleased v7 major work). Target `alpha` only when explicitly requested; otherwise offer a `stable`-compatible alternative if one exists, or decline with explanation.
 
             **Backward Compatibility — Absolute Rules**
             - `apply_filters('super_*')` and `do_action('super_*')` names are permanent public API.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,7 @@
 name: Claude Code
 
+run-name: "Claude Code · ${{ github.event_name }} · #${{ github.event.issue.number || github.event.pull_request.number || github.run_id }} · ${{ github.event.issue.title || github.event.pull_request.title || 'untitled' }}"
+
 on:
   issue_comment:
     types: [created]
@@ -10,6 +12,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -18,6 +24,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -32,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -41,7 +48,58 @@ jobs:
       - name: Run Claude Code
         id: claude
         # renovate: datasource=github-releases depName=anthropics/claude-code-action
-        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262
+        uses: anthropics/claude-code-action@e34df8781c2370c1c9d3b83ae47286a7ae2d1ea6 # v1.0.135
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 20"
+          claude_args: |
+            --max-turns 30
+            --append-system-prompt "You are Claude Code, an automated contributor to Super Forms (RensTillmann/super-forms).
+
+            **Permitted Actions**
+            - Read files, search the codebase (grep, find, read)
+            - Create branches from `master` (naming: `claude/issue-{number}-{YYYYMMDD}`)
+            - Commit to your own branch and push
+            - Open PRs targeting `master`
+            - Comment on issues and PRs with research findings
+
+            **Prohibited Actions**
+            - Pushing directly to `master`, `next/v7`, `dev`, `dev2`, or branches you didn't create
+            - Opening PRs targeting `next/v7`
+            - Renaming or removing any `super_*` hook or filter
+            - Using `get_post_meta()` for contact entry data (use `SUPER_Data_Access::get_entry_data()`)
+            - Renaming Action Scheduler hook names
+            - Removing public add-on class methods without a deprecation path
+
+            **Required Checklist Before Every Commit**
+            1. PHP syntax valid in all modified `.php` files
+            2. If any `.js` was modified: `npm run jshint` passes (run it, don't assume)
+            3. No `get_post_meta()` added for contact entry retrieval
+            4. No `super_*` hook changed or removed
+            5. No `[super_form]` shortcode attribute removed or renamed
+            6. New hooks/attributes/option keys documented in code comment or PR body
+
+            **Branch Rules**
+            - Always branch from latest `origin/master`
+            - Naming: `claude/issue-{number}-{YYYYMMDD}`
+            - All PRs target `master`
+
+            **Handling next/v7 Requests**
+            If asked to implement Automations, Themes, MCP server, React admin, or shadcn/Tailwind/Vite UI features: explain these belong to `next/v7` (unreleased), offer a master-compatible alternative if one exists, otherwise decline with explanation. Never silently attempt to implement next/v7 features against master.
+
+            **Backward Compatibility — Absolute Rules**
+            - `apply_filters('super_*')` and `do_action('super_*')` names are permanent public API.
+            - `[super_form]` shortcode attributes are permanent — never remove or rename.
+            - Contact entry retrieval must always go through `SUPER_Data_Access`.
+            - Action Scheduler task hooks must never be renamed after first release.
+            - WordPress option keys (`super_*`) must not be renamed without an upgrade migration."
+
+      - name: Push WIP branch if Claude exited mid-run
+        if: always() && steps.claude.outputs.branch_name != ''
+        run: |
+          BRANCH="${{ steps.claude.outputs.branch_name }}"
+          if git rev-parse --verify "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "Pushing local branch $BRANCH (safety net for mid-run exit)"
+            git push origin "$BRANCH" 2>&1 || echo "Push: nothing new (already up-to-date or no commits ahead)"
+          else
+            echo "Branch $BRANCH not present locally; nothing to push"
+          fi

--- a/.github/workflows/leak-scan.yml
+++ b/.github/workflows/leak-scan.yml
@@ -1,0 +1,55 @@
+# .github/workflows/leak-scan.yml
+#
+# Public super-forms repo: detect prohibited internal vocabulary in PRs
+# that touch release-body-shaped files (CHANGELOG, readme.txt, release-notes/).
+#
+# Runtime: `.github/scripts/leak-scan.cjs`, generated from the private
+# operator-side prohibited-language pattern catalogue.
+#
+# Default: BLOCKER hits fail the job. WARN-severity patterns are intentionally
+# not surfaced in this fail-closed public CI gate.
+
+name: leak-scan
+
+on:
+  pull_request:
+    paths:
+      - 'CHANGELOG*.md'
+      - 'readme.txt'
+      - 'release-notes/**'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: List candidate files changed by this PR
+        id: candidates
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          BASE_SHA=$(git merge-base "origin/${BASE_REF}" HEAD)
+          git diff --name-only "${BASE_SHA}" HEAD \
+            | grep -E '^(CHANGELOG.*\.md|readme\.txt|release-notes/)' \
+            > /tmp/candidates.txt || true
+          echo "candidate files:"
+          cat /tmp/candidates.txt || true
+
+      - name: Scan each candidate for prohibited language (release_body audience)
+        run: |
+          set -uo pipefail
+          if [[ ! -s /tmp/candidates.txt ]]; then
+            echo "No candidate files changed; nothing to scan."
+            exit 0
+          fi
+          fail=0
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            if ! node .github/scripts/leak-scan.cjs "$f" --audience release_body; then
+              fail=1
+            fi
+          done < /tmp/candidates.txt
+          exit "$fail"

--- a/.github/workflows/verification-required.yml
+++ b/.github/workflows/verification-required.yml
@@ -1,0 +1,43 @@
+# .github/workflows/verification-required.yml
+#
+# Public super-forms repo: require every PR body to include a `## Verification`
+# section so the reviewer can trace what was tested before merge.
+#
+# Rationale: bot-authored and human-authored PRs must carry a `## Verification`
+# section. Without it, a PR can land with no trace of smoke tests, unit checks,
+# E2E checks, compatibility review, or language scan results.
+#
+# Default: require a top-level `## Verification` heading. A checklist-only shape
+# is intentionally rejected because headings are easier to review and enforce.
+
+name: verification-required
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  check-body:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Require ## Verification heading in PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          body=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body --jq .body)
+          if [[ -z "$body" ]]; then
+            echo "PR body is empty; ## Verification heading missing."
+            exit 1
+          fi
+          if printf '%s\n' "$body" | grep -qE '^## Verification'; then
+            echo "Found ## Verification heading."
+            exit 0
+          fi
+          echo "::error::PR body is missing the required '## Verification' heading."
+          echo "Add a top-level '## Verification' section describing the tests, manual checks,"
+          echo "or reviewer steps that prove the change works on the target channel(s)."
+          exit 1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,19 +1,28 @@
 name: Verify
 
+run-name: "Verify · #${{ github.event.pull_request.number }} · ${{ github.event.pull_request.title }}"
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: verify-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -55,3 +64,23 @@ jobs:
           git config --global user.name "GitHub CI"
       - name: Production build
         run: npm run prod
+
+  phplint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          tools: composer
+      - name: Validate composer.json
+        run: composer validate
+      - name: PHP syntax check (src/)
+        run: |
+          set -eo pipefail
+          find src -type f -name '*.php' -print0 | xargs -0 -n1 php -l > /dev/null
+          echo "All src/**/*.php files passed syntax check"


### PR DESCRIPTION
## Summary

- Update the Claude Code and Claude PR Review workflow prompts for the current branch model.
- Add a release-body prohibited-language scan workflow plus its vendored Node runtime.
- Add a PR-body check that requires a top-level `## Verification` section.
- Update the PR template target-branch checklist and rename `## Testing` to `## Verification`.

## Verification

- Parsed `.github/workflows/claude.yml`, `.github/workflows/claude-review.yml`, `.github/workflows/verify.yml`, `.github/workflows/leak-scan.yml`, and `.github/workflows/verification-required.yml` with `yaml.safe_load`.
- Ran `node --check .github/scripts/leak-scan.cjs`.
- Ran the vendored scanner against `.github/workflows/leak-scan.yml` and `.github/workflows/verification-required.yml` with `--audience repo_file`; both clean.
- Ran the private scanner against `.github/scripts/leak-scan.cjs`, `.github/workflows/leak-scan.yml`, `.github/workflows/verification-required.yml`, and `.github/PULL_REQUEST_TEMPLATE.md` using their intended repo-relative paths; all clean.
- In the operator workspace, ran `bun run test src/scripts/export-leak-patterns.test.ts src/lib/customer-facing-language-scan.test.ts` (39 passed), `bun run test src/scripts/source-workspace.test.ts` (15 passed), `bun run test src/lib/v7-cross-axis-verifier.test.ts src/scripts/recheck-synthesize.test.ts` (67 passed), and `NODE_OPTIONS="--max-old-space-size=4096" node_modules/.bin/tsc --noEmit`.