### PR TITLE
Security: harden form file-upload handling (CVE-2026-14894); v6.3.314

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@
 
 - [PDF Generator Add-on](https://renstillmann.github.io/super-forms/#/pdf-generator-add-on)
 
+## Jul 07, 2026 - Version 6.3.314
+
+- **Security fix:** Hardened form file-upload handling to prevent unauthorized file writes (CVE-2026-14894).
+
 ## May 31, 2026 - Version 6.3.313
 
 - **Improved:** Compatibility with WordPress 7.0

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -2745,6 +2745,10 @@ class SUPER_Ajax {
                             // If there is a generated PDF let it act as a regular file upload
                             // Try to generate PDF file
                             if(isset($value['datauristring'])){
+                                if ( empty( $settings['_pdf']['generate'] ) || $settings['_pdf']['generate'] !== 'true' ) {
+                                    unset( $data[ $k ]['files'][ $key ]['datauristring'] );
+                                    continue;
+                                }
                                 try {
                                     $imgData = str_replace( ' ', '+', $value['datauristring']);
                                     unset($value['datauristring']);
@@ -2759,11 +2763,37 @@ class SUPER_Ajax {
                                     $d = $GLOBALS['super_upload_dir'];
                                     $value['value'] = SUPER_Common::email_tags( $value['value'], $data, $settings );
                                     $value['label'] = SUPER_Common::email_tags( $value['label'], $data, $settings );
-                                    $basename = $value['value'];
-                                    $filename = trailingslashit($d['path']) . $basename;
-                                    $file = fopen($filename, 'w');
-                                    fwrite($file, $imgData);
-                                    fclose($file);
+                                    $basename = sanitize_file_name( wp_basename( (string) $value['value'] ) );
+                                    $stem     = preg_replace( '/\.[^.]*$/', '', $basename ); // drop trailing extension
+                                    $stem     = str_replace( '.', '_', (string) $stem );      // neutralize interior dots (no shell.php.pdf)
+                                    $stem     = trim( $stem, '.-_' );
+                                    if ( '' === $stem ) {
+                                        $stem = 'super-forms-' . strtotime( date_i18n( 'Y-m-d H:i:s' ) );
+                                    }
+                                    $basename       = $stem . '.pdf';
+                                    $value['value'] = $basename; // keep entry/email display in sync with the safe on-disk name
+                                    $value['name']  = $basename;
+                                    if ( '%PDF-' !== substr( (string) $imgData, 0, 5 ) ) { // decoded payload must really be a PDF
+                                        throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+                                    }
+                                    $baseDir = realpath( $d['path'] );
+                                    if ( false === $baseDir ) {
+                                        throw new Exception( esc_html__( 'Invalid upload directory.', 'super-forms' ) );
+                                    }
+                                    $filename   = trailingslashit( $baseDir ) . $basename;
+                                    $parentReal = realpath( dirname( $filename ) );
+                                    if ( false === $parentReal || 0 !== strpos( trailingslashit( $parentReal ), trailingslashit( $baseDir ) ) ) {
+                                        throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+                                    }
+                                    $file = fopen( $filename, 'wb' ); // binary mode so the PDF is not CRLF-mangled
+                                    if ( false === $file ) {
+                                        throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+                                    }
+                                    if ( false === fwrite( $file, $imgData ) ) {
+                                        fclose( $file );
+                                        throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+                                    }
+                                    fclose( $file );
                                     // Add file to media library 
                                     $attachment = array(
                                         'post_mime_type' => 'application/pdf', // $uploaded_file['type'],

--- a/super-forms.php
+++ b/super-forms.php
@@ -11,7 +11,7 @@
  * @wordpress-plugin
  * Plugin Name:       Super Forms - Drag & Drop Form Builder
  * Description:       The most advanced, flexible and easy to use form builder for WordPress!
- * Version:           6.3.313
+ * Version:           6.3.314
  * Plugin URI:        http://f4d.nl/super-forms
  * Author URI:        http://f4d.nl/super-forms
  * Author:            feeling4design
@@ -44,7 +44,7 @@ if(!class_exists('SUPER_Forms')) :
          *
          *  @since      1.0.0
         */
-        public $version = '6.3.313';
+        public $version = '6.3.314';
         public $slug = 'super-forms';
         public $apiUrl = 'https://api.super-forms.com/';
         public $apiVersion = 'v1';


### PR DESCRIPTION
Fast-forwards `lts/6.3.x` to include the v6.3.314 security backport that was published on 2026-07-07 (tag `v6.3.314` = commit `4ce3387a`, GitHub Release live, delivered to customers via f4d.nl/updates.super-forms.com).

The tag was pushed but the direct branch push was declined by the branch protection rule; this PR is the tracked path to catch the branch up.

**Change:** single commit hardens the `submit_form()` datauristring branch in `includes/class-ajax.php` — gates on `_pdf.generate=true`, forces a safe `.pdf` filename, verifies `%PDF-` magic, enforces realpath containment. Version 6.3.314 in `super-forms.php` header and $version property. Adds the changelog entry.

**Reference:** https://github.com/RensTillmann/super-forms/releases/tag/v6.3.314