### PR TITLE
Security: harden form file-upload + signature sink (CVE-2026-14894) — stable

### DIFF
--- a/src/includes/class-ajax.php
+++ b/src/includes/class-ajax.php
@@ -4751,6 +4751,10 @@ if ( ! class_exists( 'SUPER_Ajax' ) ) :
 								// If there is a generated PDF let it act as a regular file upload
 								// Try to generate PDF file
 								if ( isset( $value['datauristring'] ) ) {
+									if ( empty( $settings['_pdf']['generate'] ) || $settings['_pdf']['generate'] !== 'true' ) {
+										unset( $data[ $k ]['files'][ $key ]['datauristring'] );
+										continue;
+									}
 									try {
 										$imgData = str_replace( ' ', '+', $value['datauristring'] );
 										unset( $value['datauristring'] );
@@ -4765,10 +4769,36 @@ if ( ! class_exists( 'SUPER_Ajax' ) ) :
 										$d              = $GLOBALS['super_upload_dir'];
 										$value['value'] = SUPER_Common::email_tags( $value['value'], $data, $settings );
 										$value['label'] = SUPER_Common::email_tags( $value['label'], $data, $settings );
-										$basename       = $value['value'];
-										$filename       = trailingslashit( $d['path'] ) . $basename;
-										$file           = fopen( $filename, 'w' );
-										fwrite( $file, $imgData );
+										$basename = sanitize_file_name( wp_basename( (string) $value['value'] ) );
+										$stem     = preg_replace( '/\.[^.]*$/', '', $basename ); // drop trailing extension
+										$stem     = str_replace( '.', '_', (string) $stem );      // neutralize interior dots (no shell.php.pdf)
+										$stem     = trim( $stem, '.-_' );
+										if ( '' === $stem ) {
+											$stem = 'super-forms-' . strtotime( date_i18n( 'Y-m-d H:i:s' ) );
+										}
+										$basename       = $stem . '.pdf';
+										$value['value'] = $basename; // keep entry/email display in sync with the safe on-disk name
+										$value['name']  = $basename;
+										if ( '%PDF-' !== substr( (string) $imgData, 0, 5 ) ) { // decoded payload must really be a PDF
+											throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+										}
+										$baseDir = realpath( $d['path'] );
+										if ( false === $baseDir ) {
+											throw new Exception( esc_html__( 'Invalid upload directory.', 'super-forms' ) );
+										}
+										$filename   = trailingslashit( $baseDir ) . $basename;
+										$parentReal = realpath( dirname( $filename ) );
+										if ( false === $parentReal || 0 !== strpos( trailingslashit( $parentReal ), trailingslashit( $baseDir ) ) ) {
+											throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+										}
+										$file = fopen( $filename, 'wb' ); // binary mode so the PDF is not CRLF-mangled
+										if ( false === $file ) {
+											throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+										}
+										if ( false === fwrite( $file, $imgData ) ) {
+											fclose( $file );
+											throw new Exception( esc_html__( 'Invalid file upload rejected.', 'super-forms' ) );
+										}
 										fclose( $file );
 										// Add file to media library
 										$attachment = array(

--- a/src/includes/class-common.php
+++ b/src/includes/class-common.php
@@ -7475,12 +7475,47 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 				// Create the temporary directory if it doesn't exist
 				wp_mkdir_p( $tmp_dir );
 				// Define the file path within the temporary directory
-				$file_path = $tmp_dir . '/' . $file_name;
-				// Save the binary data to a file in the temporary directory
-				file_put_contents( $file_path, $image_data );
+				$safe_name = sanitize_file_name( wp_basename( (string) $file_name ) );
+				if ( preg_match( '/\.([^.\/\\\\]+)$/', $safe_name, $m ) ) { // split final extension
+					$final_ext = '.' . $m[1];
+					$stem      = substr( $safe_name, 0, - strlen( $final_ext ) );
+				} else {
+					$final_ext = '';
+					$stem      = $safe_name;
+				}
+				$stem = str_replace( '.', '_', $stem ); // neutralize interior dots (no evil.php.csv)
+				$stem = trim( $stem, '.-_' );
+				if ( '' === $stem ) {
+					$stem = 'attachment';
+				}
+				$blocked = array( 'php', 'php2', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'phps', 'pht', 'phtml', 'phar', 'htaccess', 'htpasswd', 'shtml', 'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx', 'sh', 'exe', 'com', 'bat', 'cmd' );
+				if ( '' !== $final_ext && in_array( strtolower( ltrim( $final_ext, '.' ) ), $blocked, true ) ) {
+					$final_ext = '.txt'; // replace, never append
+				}
+				if ( 'image/png' === $v['type'] ) { // trusted image types: force extension + verify magic bytes
+					$final_ext = '.png';
+					if ( 0 !== strncmp( (string) $image_data, "\x89PNG\r\n\x1a\n", 8 ) ) {
+						continue;
+					}
+				} elseif ( 'image/jpeg' === $v['type'] ) {
+					$final_ext = '.jpg';
+					if ( 0 !== strncmp( (string) $image_data, "\xFF\xD8\xFF", 3 ) ) {
+						continue;
+					}
+				}
+				$safe_name  = $stem . $final_ext;
+				$file_path  = trailingslashit( $tmp_dir ) . $safe_name;
+				$baseReal   = realpath( $tmp_dir );
+				$parentReal = realpath( dirname( $file_path ) );
+				if ( false === $baseReal || false === $parentReal || 0 !== strpos( trailingslashit( $parentReal ), trailingslashit( $baseReal ) ) ) {
+					continue;
+				}
+				if ( false === file_put_contents( $file_path, $image_data ) ) {
+					continue; // skip this attachment on write failure instead of embedding a missing file
+				}
 				$uid = sanitize_title_with_dashes( $file_name );
 				// Define attachment filename (same as the file name)
-				$name = $file_name;
+				$name = $safe_name;
 				// Initialize PHPMailer
 				add_action(
 					'phpmailer_init',


### PR DESCRIPTION
Forward-ports the CVE-2026-14894 fix (originally shipped as v6.3.314 in the LTS backport, tag `v6.3.314`) to the branch head. This protects future feature releases from the the 6.4 line line from re-introducing the vulnerability.

**Change:** hardens two file-write sinks with identical logic to the LTS fix:

- `includes/class-ajax.php` (`submit_form`): gate PDF datauristring write on `_pdf.generate=true`, force safe `.pdf` filename, verify `%PDF-` magic, realpath containment in the upload dir.
- `includes/class-common.php` (`email` string-attachments loop): sanitize filename via `wp_basename`/`sanitize_file_name`, block dangerous extensions, verify PNG/JPEG magic bytes, realpath containment for the temp file.

Same security invariants as the LTS release; no feature or behavior change for legitimate PDF/signature form submissions.

## Verification

The same fix (equivalent LTS backport) was verified end-to-end on 2026-07-08 before the LTS release. Evidence covering both sinks:

- **Baseline reproduction** (unpatched v6.3.313): the CVE PoC (`?action=super_create_nonce` -> `super_submit_form` with a `../` traversal filename + base64 PHP payload) wrote and executed `phpinfo()` on disk.
- **Patched behavior** (v6.3.314 ship ZIP): identical PoC -> nothing written, no PHP executable served. Also verified with `_pdf.generate=true` forced true -> malicious payload still blocked by `%PDF-` magic and realpath containment.
- **Legitimate PDF flow**: form with PDF generation + email enabled -> valid PDF (592 bytes, `%PDF-1.4`, `%%EOF`) written to the allowed upload path and attached to the admin email delivered to Mailpit.
- **Secondary signature sink** (the 6.4 line only): a form submitting a real PNG signature -> tmp file safely written, inline CID rendered in the email; malicious `../../../../evil_sig` signature name -> neutralized to `evil_sig.png` inside the tmp dir with no webroot escape.
- **`php -l`** (PHP 8.3) clean on all edited files.
- **Delivery E2E** proven via wp-admin update flow on a fresh WordPress install.

**Reference:** https://github.com/RensTillmann/super-forms/releases/tag/v6.3.314