### PR TITLE
docs(gitbook): add v6.3.314 + v6.4.004-beta security release entries

### DIFF
--- a/gitbook-docs/changelog.md
+++ b/gitbook-docs/changelog.md
@@ -11,6 +11,14 @@ description: New features, improvements and bug fixes.
 * [Listings Add-on](features/integrations/listings.md)
 * [PDF Generator Add-on](features/integrations/pdf-generator.md)
 
+### Jul 07, 2026 - Version 6.4.004-beta
+
+* **Security fix:** Hardened form file-upload and signature handling to prevent unauthorized file writes (CVE-2026-14894).
+
+### Jul 07, 2026 - Version 6.3.314
+
+* **Security fix:** Hardened form file-upload handling to prevent unauthorized file writes (CVE-2026-14894).
+
 ### Apr 24, 2024 - Version 6.4.003-beta
 
 * **Added:** New \[Stripe] tab to configure Stripe checkout, allowing for one time payments and recurring payments.


### PR DESCRIPTION
Adds changelog entries for the two CVE-2026-14894 security releases so `docs.super-forms.com` (GitBook-synced from `gitbook-docs/`) reflects the fixes visible on other release channels (in-plugin `docs/changelog.md`, f4d.nl metadata, GitHub Releases).

**Entries added (customer-facing changelog voice):**

- `Jul 07, 2026 - Version 6.4.004-beta` — Security fix: Hardened form file-upload and signature handling to prevent unauthorized file writes (CVE-2026-14894).
- `Jul 07, 2026 - Version 6.3.314` — Security fix: Hardened form file-upload handling to prevent unauthorized file writes (CVE-2026-14894).

Docs-only change. No plugin behavior.

## Verification

- Format matches the existing `### Mon DD, YYYY - Version X.Y.Z` heading style used throughout the file (checked against the prior `Apr 24, 2024 - Version 6.4.003-beta` entry).
- Wording matches the plugin-bundled `docs/changelog.md` entries shipped in v6.3.314 and v6.4.004-beta.
- No secrets, no infrastructure/branch references, no v7/internal roadmap wording.

**References:**
- https://github.com/RensTillmann/super-forms/releases/tag/v6.3.314
- https://github.com/RensTillmann/super-forms/releases/tag/v6.4.004-beta
