### PR TITLE
Embed signature images via a single self-removing phpmailer_init callback

### DIFF
--- a/src/includes/class-common.php
+++ b/src/includes/class-common.php
@@ -7457,6 +7457,8 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 				$global_settings['smtp_enabled'] = 'disabled';
 			}
 
+			// Collect inline (embedded) images and register them via one self-removing callback below.
+			$embedded_images = array();
 			foreach ( $string_attachments as $k => $v ) {
 				if ( $v['encoding'] == 'base64' && ( $v['type'] == 'image/png' || $v['type'] == 'image/jpeg' ) ) {
 					$v['data'] = substr( $v['data'], strpos( $v['data'], ',' ) );
@@ -7516,14 +7518,33 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 				$uid = sanitize_title_with_dashes( $file_name );
 				// Define attachment filename (same as the file name)
 				$name = $safe_name;
-				// Initialize PHPMailer
-				add_action(
-					'phpmailer_init',
-					function ( &$phpmailer ) use ( $file_path, $uid, $name ) {
-						$phpmailer->SMTPKeepAlive = true;
-						$phpmailer->AddEmbeddedImage( $file_path, $uid, $name );
-					}
+				// Queue the inline image; it is embedded once, right before the message is sent (see below).
+				$embedded_images[] = array(
+					'path' => $file_path,
+					'cid'  => $uid,
+					'name' => $name,
 				);
+			}
+
+			// Embed all queued inline images through a single `phpmailer_init` callback that removes
+			// itself right after it runs. Self-removal guarantees it only affects the wp_mail() call it
+			// was registered for; a leftover closure would otherwise re-fire on the next wp_mail() in the
+			// same request (e.g. the confirmation email when confirm=yes) and reference an already
+			// cleaned-up temp file, causing PHPMailer to throw "Could not access file" and a PHP fatal.
+			if ( ! empty( $embedded_images ) ) {
+				$embed_images_cb = null;
+				$embed_images_cb = function ( &$phpmailer ) use ( $embedded_images, &$embed_images_cb ) {
+					remove_action( 'phpmailer_init', $embed_images_cb );
+					$phpmailer->SMTPKeepAlive = true;
+					foreach ( $embedded_images as $img ) {
+						// Defensive: skip if the temp file no longer exists so a stale re-fire cannot fatal.
+						if ( ! file_exists( $img['path'] ) ) {
+							continue;
+						}
+						$phpmailer->AddEmbeddedImage( $img['path'], $img['cid'], $img['name'] );
+					}
+				};
+				add_action( 'phpmailer_init', $embed_images_cb );
 			}
 
 			if ( $global_settings['smtp_enabled'] == 'disabled' ) {


### PR DESCRIPTION
Hardens the signature email embed path in SUPER_Common::email().

Previously each signature registered its own phpmailer_init closure that was never removed, so every later wp_mail() call in the same request re-fired stale closures. On code lines that delete the signature temp file right after each send (an earlier public beta build), the re-fire made PHPMailer throw "Could not access file" and the submit returned a server error after the first email had already gone out. On this branch the temp files persist briefly, so the re-fire instead silently re-embedded earlier signatures into later, unrelated emails.

This change queues all inline images and registers ONE callback that removes itself after it runs, plus a file_exists guard so a missing temp file can never turn into a fatal. Other phpmailer_init listeners are untouched.


Changed files:
- src/includes/class-common.php
## Verification

- End to end on the WordPress test stack: a signature form with admin plus confirmation email delivers BOTH emails with the signature embedded as a real inline image part in each.
- The plain email suite passes unchanged.
- php lint clean on the changed file.
- The no stale re-fire properties (no re-embedding into later unrelated emails, no crash on a deleted temp file) follow from code analysis of the self-removing callback and the file_exists guard; they are not separately exercised by the end to end suite.