### PR TITLE
Attach signature images as regular email attachments alongside the inline embed

### DIFF
--- a/src/add-ons/super-forms-signature/super-forms-signature.php
+++ b/src/add-ons/super-forms-signature/super-forms-signature.php
@@ -547,6 +547,12 @@ if ( ! class_exists( 'SUPER_Signature' ) ) :
 					'filename' => $signature_filename,
 					'encoding' => $signature_encoding,
 					'type'     => $signature_type,
+					// Attach the signature ALSO as a regular (non-inline) email attachment, on top of
+					// the inline cid embed used in the HTML body. This guarantees the signature is
+					// accessible in plain-text views and in clients/filters that suppress inline images.
+					// SUPER_Common::email() reads this flag from the embedded_images queue and only then
+					// calls PHPMailer addAttachment(); base64 string attachments without it stay inline-only.
+					'attach_as_file' => true,
 				);
 				// Check if we should exclude the file from emails
 				// 0 = Do not exclude from e-mails

--- a/src/includes/class-common.php
+++ b/src/includes/class-common.php
@@ -7523,6 +7523,10 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 					'path' => $file_path,
 					'cid'  => $uid,
 					'name' => $name,
+					// @since - flag whether this inline image should ALSO be attached as a regular
+					// (non-inline) attachment part. Defaults to false so existing base64 string
+					// attachments (that do not set `attach_as_file`) keep their inline-only behavior.
+					'attach' => ( isset( $v['attach_as_file'] ) ? (bool) $v['attach_as_file'] : false ),
 				);
 			}
 
@@ -7542,6 +7546,13 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 							continue;
 						}
 						$phpmailer->AddEmbeddedImage( $img['path'], $img['cid'], $img['name'] );
+						// Also attach the same file as a regular (non-inline) attachment when flagged.
+						// The inline embed above keeps HTML clients rendering the image; the regular
+						// attachment guarantees plain-text views and clients/filters that suppress
+						// inline parts can still access the file. Guarded by the same file_exists check.
+						if ( ! empty( $img['attach'] ) ) {
+							$phpmailer->addAttachment( $img['path'], $img['name'] );
+						}
 					}
 				};
 				add_action( 'phpmailer_init', $embed_images_cb );


### PR DESCRIPTION
Signature images previously rode ONLY as inline (cid) MIME parts, referenced by an img tag in the HTML body. Plain-text views and some clients or filters that suppress inline images cannot see them, and a subset does not list inline parts as attachments at all.

This change also attaches each signature as a regular attachment part (PHPMailer addAttachment) from the same self-removing phpmailer_init callback, guarded by the same file_exists check. The inline embed stays for HTML display; the regular attachment guarantees every client can access the file. Signature entries are flagged explicitly; other base64 string attachments keep their current inline-only behavior.

The dual behavior is always on for signatures in this change. A per-element opt-out checkbox for users who prefer a single copy can follow separately if wanted.


Builds on the signature embed hardening branch; merge that first and this diff reduces to the 17 added lines.

Changed files:
- src/includes/class-common.php
- src/add-ons/super-forms-signature/super-forms-signature.php
## Verification

- End to end on the WordPress test stack: a signature form with admin plus confirmation email delivers both emails carrying the signature BOTH as the inline cid part AND as a regular image/png attachment part, asserted against the raw MIME parts of each message.
- The no signature email suite passes unchanged.
- php lint clean on both changed files.