### PR TITLE
Per-email field exclusion broken in trigger email path (type hardcoded to admin)

### DIFF
--- a/src/includes/class-common.php
+++ b/src/includes/class-common.php
@@ -305,12 +305,21 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 							'attachments'       => '',
 							'exclude_empty'     => 'false',
 							'rtl'               => 'false',
+							'_email_type'       => ( $email_index === 0 ? 'admin' : 'confirm' ),
 							'exclude'           => array(
 								'enabled'        => 'false',
 								'exclude_fields' => array(),
 							),
 						),
 					);
+				}
+
+				// Backfill the per-email role for already-shaped { enabled, name, data } entries
+				// that predate the annotation, so the trigger email path can honor per-email field
+				// exclusion (1 = exclude from confirmation, 3 = exclude from admin). The flat
+				// conversion above already sets it by position, so this only fills the gap.
+				if ( isset( $email_settings['data'] ) && is_array( $email_settings['data'] ) && ! isset( $email_settings['data']['_email_type'] ) ) {
+					$email_settings['data']['_email_type'] = ( isset( $email_settings['name'] ) && $email_settings['name'] === 'Confirmation E-mail' ? 'confirm' : 'admin' );
 				}
 
 				// Only add trigger if email is enabled
@@ -4161,6 +4170,7 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 							'attachments' => ( ! empty( $s['admin_attachments'] ) ? $s['admin_attachments'] : '' ),
 							'content_type' => 'html',
 							'charset' => 'UTF-8',
+							'_email_type' => 'admin',
 						),
 					);
 				}
@@ -4192,6 +4202,7 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 							'attachments' => ( ! empty( $s['confirm_attachments'] ) ? $s['confirm_attachments'] : '' ),
 							'content_type' => 'html',
 							'charset' => 'UTF-8',
+							'_email_type' => 'confirm',
 						),
 					);
 				}
@@ -4225,6 +4236,7 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 								'attachments' => ( ! empty( $s[$reminder_key . '_attachments'] ) ? $s[$reminder_key . '_attachments'] : '' ),
 								'content_type' => 'html',
 								'charset' => 'UTF-8',
+								'_email_type' => 'confirm',
 								// Email reminder specific fields - use correct UI structure
 								'schedule' => array(
 									'enabled' => 'true',

--- a/src/includes/class-triggers.php
+++ b/src/includes/class-triggers.php
@@ -512,6 +512,12 @@ if ( ! class_exists( 'SUPER_Triggers' ) ) :
 			$email_loop         = '';
 			$attachments        = array();
 			$string_attachments = array();
+			// Per-email role for the specific email being assembled (admin|confirm), threaded
+			// from the _emails entry's data as `_email_type`. Lets filter consumers (e.g. the
+			// Signature add-on) honor per-email field exclusion again: 1 = exclude from the
+			// confirmation email, 3 = exclude from the admin email. Defaults to 'admin' so any
+			// entry missing the annotation keeps its prior behavior.
+			$email_type = isset( $options['_email_type'] ) ? $options['_email_type'] : 'admin';
 			if ( ( isset( $data ) ) && ( count( $data ) > 0 ) ) {
 				foreach ( $data as $k => $v ) {
 					// Skip excluded fields
@@ -532,19 +538,30 @@ if ( ! class_exists( 'SUPER_Triggers' ) ) :
 						'super_before_email_loop_data_filter',
 						$row,
 						array(
-							'type'               => 'admin',
-							'v'                  => $v,
-							'string_attachments' => $string_attachments,
+							'type'                       => $email_type,
+							'v'                          => $v,
+							'string_attachments'         => $string_attachments,
+							'confirm_string_attachments' => $string_attachments,
 						)
 					);
 					$continue = false;
 					if ( isset( $result['status'] ) ) {
 						if ( $result['status'] == 'continue' ) {
-							if ( isset( $result['string_attachments'] ) ) {
+							// Confirm-role consumers return attachments under 'confirm_string_attachments';
+							// the admin/listing roles use 'string_attachments'. Only one role is built per email.
+							if ( $email_type === 'confirm' ) {
+								if ( isset( $result['confirm_string_attachments'] ) ) {
+									$string_attachments = $result['confirm_string_attachments'];
+								}
+							} elseif ( isset( $result['string_attachments'] ) ) {
 								$string_attachments = $result['string_attachments'];
 							}
-							if ( ( isset( $result['exclude'] ) ) && ( $result['exclude'] == 3 ) ) {
-							} else {
+							// Skip the row when excluded for THIS email's role (1 = confirm, 3 = admin).
+							$exclude_row = false;
+							if ( isset( $result['exclude'] ) ) {
+								$exclude_row = ( $email_type === 'confirm' ) ? ( $result['exclude'] == 1 ) : ( $result['exclude'] == 3 );
+							}
+							if ( ! $exclude_row ) {
 								$email_loop .= $result['row'];
 							}
 							$continue = true;

--- a/tests/test-trigger-email-exclusion.php
+++ b/tests/test-trigger-email-exclusion.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Test per-email field exclusion in the trigger email path.
+ *
+ * Regression coverage for the bug where SUPER_Triggers::retrieve_email_loop_html()
+ * hardcoded the filter `type` to 'admin' for every email it assembled, which made the
+ * per-email exclude options unreachable for confirmation emails:
+ *   - exclude = 1 (exclude from confirmation) leaked the field/attachment into the
+ *     confirmation email anyway.
+ *   - exclude = 3 (exclude from admin) dropped the field/attachment from ALL emails.
+ *
+ * The role is now threaded through the _emails entry data as `_email_type` and passed
+ * to the `super_before_email_loop_data_filter` consumers (here the Signature add-on).
+ *
+ * @package Super_Forms\Tests
+ */
+
+require_once 'class-test-helpers.php';
+
+class Test_Trigger_Email_Exclusion extends SUPER_Test_Helpers {
+
+	/**
+	 * A data URI value that the Signature add-on recognizes as a drawn signature.
+	 */
+	const SIGNATURE_VALUE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+	public function set_up() {
+		parent::set_up();
+		// Load the Signature add-on so its `super_before_email_loop_data_filter` consumer
+		// (the sole registered consumer) is active. The file self-registers exactly once.
+		require_once dirname( __DIR__ ) . '/src/add-ons/super-forms-signature/super-forms-signature.php';
+	}
+
+	/**
+	 * Assemble the email loop for a single signature field.
+	 *
+	 * @param int         $exclude    Field exclude setting (0|1|2|3).
+	 * @param string|null $email_type Role to thread as `_email_type`, or null to omit it.
+	 * @return array retrieve_email_loop_html() result.
+	 */
+	private function run_loop( $exclude, $email_type = null ) {
+		$data = array(
+			'signature' => array(
+				'name'    => 'signature',
+				'label'   => 'Signature:',
+				'type'    => 'signature',
+				'value'   => self::SIGNATURE_VALUE,
+				'exclude' => $exclude,
+			),
+		);
+		$settings = array();
+		$options  = array(
+			'loop'          => '{loop_label} {loop_value}',
+			'exclude_empty' => 'false',
+			'exclude'       => array(
+				'enabled'        => 'false',
+				'exclude_fields' => array(),
+			),
+		);
+		if ( null !== $email_type ) {
+			$options['_email_type'] = $email_type;
+		}
+		return SUPER_Triggers::retrieve_email_loop_html( $data, $settings, $options );
+	}
+
+	public function test_exclude_from_confirmation_keeps_admin_drops_confirm() {
+		// exclude = 1 -> keep in admin email, drop from confirmation email.
+		$confirm = $this->run_loop( 1, 'confirm' );
+		$this->assertCount( 0, $confirm['string_attachments'], 'Confirmation email must not embed the signature when exclude=1.' );
+		$this->assertStringNotContainsString( 'cid:', $confirm['email_loop'], 'Confirmation loop must not reference the signature image when exclude=1.' );
+
+		$admin = $this->run_loop( 1, 'admin' );
+		$this->assertCount( 1, $admin['string_attachments'], 'Admin email must keep the signature when exclude=1.' );
+		$this->assertSame( 'signature.png', $admin['string_attachments'][0]['filename'] );
+		$this->assertStringContainsString( 'cid:', $admin['email_loop'], 'Admin loop must reference the signature image when exclude=1.' );
+	}
+
+	public function test_exclude_from_admin_keeps_confirm_drops_admin() {
+		// exclude = 3 -> drop from admin email, keep in confirmation email (not all emails).
+		$admin = $this->run_loop( 3, 'admin' );
+		$this->assertCount( 0, $admin['string_attachments'], 'Admin email must not embed the signature when exclude=3.' );
+		$this->assertStringNotContainsString( 'cid:', $admin['email_loop'], 'Admin loop must not reference the signature image when exclude=3.' );
+
+		$confirm = $this->run_loop( 3, 'confirm' );
+		$this->assertCount( 1, $confirm['string_attachments'], 'Confirmation email must keep the signature when exclude=3.' );
+		$this->assertSame( 'signature.png', $confirm['string_attachments'][0]['filename'] );
+		$this->assertStringContainsString( 'cid:', $confirm['email_loop'], 'Confirmation loop must reference the signature image when exclude=3.' );
+	}
+
+	public function test_no_exclusion_delivers_to_both_roles() {
+		// exclude = 0 -> both emails embed the signature.
+		$admin   = $this->run_loop( 0, 'admin' );
+		$confirm = $this->run_loop( 0, 'confirm' );
+		$this->assertCount( 1, $admin['string_attachments'], 'Admin email must embed the signature when not excluded.' );
+		$this->assertCount( 1, $confirm['string_attachments'], 'Confirmation email must embed the signature when not excluded.' );
+	}
+
+	public function test_missing_email_type_defaults_to_admin_role() {
+		// No `_email_type` on the entry -> preserve prior behavior (treat as admin email).
+		$default = $this->run_loop( 1, null );
+		$this->assertCount( 1, $default['string_attachments'], 'Entries without _email_type must behave as the admin role.' );
+
+		$excluded = $this->run_loop( 3, null );
+		$this->assertCount( 0, $excluded['string_attachments'], 'Entries without _email_type must honor admin exclusion (exclude=3).' );
+	}
+}


### PR DESCRIPTION
Automated fix via the on-box fix loop for the linked issue.

Changed files:
- src/includes/class-common.php
- src/includes/class-triggers.php
- tests/test-trigger-email-exclusion.php

## Verification

- Delivered through an internal pipeline that blocks on a public-content language scan over the diff, commit messages and this description, and on a static gate (php lint per changed PHP file, JSHint and production build when applicable).
- Behavioral end to end coverage runs when a catalog suite matches the change; results are recorded in the delivery record together with an independent automated review verdict.