### PR TITLE
Attach signature images as regular email attachments alongside the inline embed (forward-port)

### DIFF
--- a/src/add-ons/super-forms-signature/super-forms-signature.php
+++ b/src/add-ons/super-forms-signature/super-forms-signature.php
@@ -547,6 +547,12 @@ if ( ! class_exists( 'SUPER_Signature' ) ) :
 					'filename' => $signature_filename,
 					'encoding' => $signature_encoding,
 					'type'     => $signature_type,
+					// Attach the signature ALSO as a regular (non-inline) email attachment, on top of
+					// the inline cid embed used in the HTML body. This guarantees the signature is
+					// accessible in plain-text views and in clients/filters that suppress inline images.
+					// SUPER_Common::email() reads this flag from the embedded_images queue and only then
+					// calls PHPMailer addAttachment(); base64 string attachments without it stay inline-only.
+					'attach_as_file' => true,
 				);
 				// Check if we should exclude the file from emails
 				// 0 = Do not exclude from e-mails

--- a/src/includes/class-common.php
+++ b/src/includes/class-common.php
@@ -7523,6 +7523,10 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 					'path' => $file_path,
 					'cid'  => $uid,
 					'name' => $name,
+					// @since - flag whether this inline image should ALSO be attached as a regular
+					// (non-inline) attachment part. Defaults to false so existing base64 string
+					// attachments (that do not set `attach_as_file`) keep their inline-only behavior.
+					'attach' => ( isset( $v['attach_as_file'] ) ? (bool) $v['attach_as_file'] : false ),
 				);
 			}
 
@@ -7542,6 +7546,13 @@ if ( ! class_exists( 'SUPER_Common' ) ) :
 							continue;
 						}
 						$phpmailer->AddEmbeddedImage( $img['path'], $img['cid'], $img['name'] );
+						// Also attach the same file as a regular (non-inline) attachment when flagged.
+						// The inline embed above keeps HTML clients rendering the image; the regular
+						// attachment guarantees plain-text views and clients/filters that suppress
+						// inline parts can still access the file. Guarded by the same file_exists check.
+						if ( ! empty( $img['attach'] ) ) {
+							$phpmailer->addAttachment( $img['path'], $img['name'] );
+						}
 					}
 				};
 				add_action( 'phpmailer_init', $embed_images_cb );


### PR DESCRIPTION
Automated fix via the on-box fix loop for the linked issue.

Changed files:
- src/add-ons/super-forms-signature/super-forms-signature.php
- src/includes/class-common.php

## Verification

- Delivered through an internal pipeline that blocks on a public-content language scan over the diff, commit messages and this description, and on a static gate (php lint per changed PHP file, JSHint and production build when applicable).
- Behavioral end to end coverage runs when a catalog suite matches the change; results are recorded in the delivery record together with an independent automated review verdict.