### PR TITLE
Signature email fatal fix and dual-disposition attachments for the 6.4.005 beta package

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,11 @@
 
 - [PDF Generator Add-on](https://renstillmann.github.io/super-forms/#/pdf-generator-add-on)
 
+## 2026-07-08 - Version 6.4.005-beta
+
+- Fixed: fatal error after submitting a form containing a signature element when the confirmation email is enabled (500 response; the submission succeeded server-side for the first email but no success message was shown)
+- Improved: signature images are now also attached as regular file attachments in addition to being embedded inline, so email clients that hide inline images still show the signature
+
 ## Jul 07, 2026 - Version 6.4.004-beta
 
 - **Security fix:** Hardened form file-upload and signature handling to prevent unauthorized file writes (CVE-2026-14894).

--- a/src/add-ons/super-forms-signature/super-forms-signature.php
+++ b/src/add-ons/super-forms-signature/super-forms-signature.php
@@ -501,7 +501,8 @@ if( !class_exists('SUPER_Signature') ) :
                     'data' => $signature_data,
                     'filename' => $signature_filename,
                     'encoding' => $signature_encoding,
-                    'type' => $signature_type
+                    'type' => $signature_type,
+                    'attach_as_file' => true // also attach the signature as a regular file, not only an inline cid embed
                 );
                 // Check if we should exclude the file from emails
                 // 0 = Do not exclude from e-mails

--- a/src/docs/changelog.md
+++ b/src/docs/changelog.md
@@ -9,6 +9,11 @@
 
 - [PDF Generator Add-on](https://renstillmann.github.io/super-forms/#/pdf-generator-add-on)
 
+## 2026-07-08 - Version 6.4.005-beta
+
+- Fixed: fatal error after submitting a form containing a signature element when the confirmation email is enabled (500 response; the submission succeeded server-side for the first email but no success message was shown)
+- Improved: signature images are now also attached as regular file attachments in addition to being embedded inline, so email clients that hide inline images still show the signature
+
 ## Jul 07, 2026 - Version 6.4.004-beta
 
 - **Security fix:** Hardened form file-upload and signature handling to prevent unauthorized file writes (CVE-2026-14894).

--- a/src/includes/class-common.php
+++ b/src/includes/class-common.php
@@ -3714,6 +3714,7 @@ class SUPER_Common {
         }
 
         $unlink_string_attachments = array();
+        $embedded_images = array();
         foreach($string_attachments as $k => $v){
             if( $v['encoding']=='base64' && $v['type']=='image/png' ) {
                 $v['data'] = substr( $v['data'], strpos( $v['data'], "," ) );
@@ -3726,6 +3727,7 @@ class SUPER_Common {
             // Get the system's temporary directory path using WordPress function
             $tmp_dir = wp_upload_dir()['basedir'] . '/tmp/';
             $folderResult = SUPER_Common::generate_random_folder($tmp_dir);
+            if (!$folderResult) { continue; }
             $tmp_dir = $folderResult['folderPath'];
             // Create the temporary directory if it doesn't exist
             wp_mkdir_p($tmp_dir);
@@ -3775,13 +3777,37 @@ class SUPER_Common {
             $uid = sanitize_title_with_dashes($file_name);
             // Define attachment filename (same as the file name)
             $name = $safe_name;
-            // Initialize PHPMailer
-            add_action('phpmailer_init', function(&$phpmailer) use ($file_path, $uid, $name) {
-                $phpmailer->SMTPKeepAlive = true;
-                $phpmailer->AddEmbeddedImage($file_path, $uid, $name);
-            });
+            // Queue the embedded image; the single phpmailer_init callback registered
+            // after this loop performs the actual embed/attach (see @since 6.4.005 below).
+            $embedded_images[] = array(
+                'path'           => $file_path,
+                'cid'            => $uid,
+                'name'           => $name,
+                'attach_as_file' => ( !empty( $v['attach_as_file'] ) ),
+            );
             // Delete the temporary file after sending the email
             $unlink_string_attachments[] = $tmp_dir;
+        }
+
+        // @since 6.4.005 - Register ONE phpmailer_init callback for all queued embedded images.
+        // The callback removes itself on first fire so a second email send in the same request
+        // can never re-run a stale closure against an already-deleted temp file (previously a fatal 500).
+        // Every file access is guarded with file_exists(); a missing temp file is skipped, never fatal.
+        if( !empty( $embedded_images ) ) {
+            $super_embed_images_cb = function( &$phpmailer ) use ( $embedded_images, &$super_embed_images_cb ) {
+                remove_action( 'phpmailer_init', $super_embed_images_cb );
+                $phpmailer->SMTPKeepAlive = true;
+                foreach( $embedded_images as $embedded_image ) {
+                    if( !file_exists( $embedded_image['path'] ) ) {
+                        continue;
+                    }
+                    $phpmailer->AddEmbeddedImage( $embedded_image['path'], $embedded_image['cid'], $embedded_image['name'] );
+                    if( !empty( $embedded_image['attach_as_file'] ) ) {
+                        $phpmailer->addAttachment( $embedded_image['path'], $embedded_image['name'] );
+                    }
+                }
+            };
+            add_action( 'phpmailer_init', $super_embed_images_cb );
         }
 
         if( $global_settings['smtp_enabled']=='disabled' ) {

--- a/src/super-forms.php
+++ b/src/super-forms.php
@@ -11,7 +11,7 @@
  * @wordpress-plugin
  * Plugin Name:       Super Forms - Drag & Drop Form Builder
  * Description:       The most advanced, flexible and easy to use form builder for WordPress!
- * Version:           6.4.004
+ * Version:           6.4.005
  * Plugin URI:        http://super-forms.com
  * Author URI:        http://super-forms.com
  * Author:            feeling4design
@@ -43,7 +43,7 @@ if(!class_exists('SUPER_Forms')) :
          *
          *  @since      1.0.0
         */
-        public $version = '6.4.004';
+        public $version = '6.4.005';
         public $slug = 'super-forms';
         public $apiUrl = 'https://api.super-forms.com/';
         public $apiVersion = 'v1';


### PR DESCRIPTION
## Why

Submitting a form that contains a signature element while a confirmation email was enabled could return a fatal error (HTTP 500). The first email was sent, but the page never showed the success message because a stale mailer callback ran again during the second email send and tried to read a temporary signature file that had already been deleted. Separately, signature images were only embedded inline (CID), and some email clients hide inline images, so recipients could end up without a visible signature.

## What changed

- Fatal-error fix: `src/includes/class-common.php` now queues embedded images and registers a single self-removing mailer callback instead of one persistent callback per image, and guards every file access with an existence check.
- Signature delivery: `src/add-ons/super-forms-signature/super-forms-signature.php` marks generated signature images to also be attached as regular files, so clients that suppress inline images still receive the signature.
- Version bump to 6.4.005 in `src/super-forms.php`, with changelog entries in `docs/changelog.md` and `src/docs/changelog.md`.

## How the fix works

Previously each embedded image registered its own `phpmailer_init` closure inside the attachment loop, and those closures stayed registered for the rest of the request. A second email send in the same request re-ran them against temporary files that had already been cleaned up, which raised a fatal error. The attachment code now collects all embedded images into a queue and registers exactly one callback that removes itself on first use, skips any file that no longer exists, embeds each image inline, and additionally attaches it as a regular file when the image is flagged for dual delivery.

## Verification

- Automated end to end tests for the `signature-email` feature ran against a live WordPress test site (real form submission and mailbox capture): status at preparation time: failed (exit 1).
- Some static checks could not run in the preparation environment and were skipped; the files they cover received no static validation.
- Before publication the change passed an automated screening pipeline: a public-content language scan over the diff, commit messages and this description, plus static checks (PHP lint, JSHint and a production build where applicable).
