### PR TITLE
build: add .gitattributes export-ignore for reproducible lean release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Release-zip exclusions (root-layout LTS line).
+#
+# Customer zips are built with `git archive --prefix=super-forms/ <ref>`
+# from this root tree (see build-release-zip.sh). Paths marked
+# export-ignore never enter the zip.
+#
+# *.po / *.pot are translation build sources; WordPress loads only the
+# compiled *.mo files at runtime.
+.gitattributes export-ignore
+build-release-zip.sh export-ignore
+*.po export-ignore
+*.pot export-ignore


### PR DESCRIPTION
Adds a `.gitattributes` with `export-ignore` rules so `git archive` produces a lean release archive: translation source files (`*.po`, `*.pot`) are excluded while the compiled runtime `*.mo` files are kept. Build-tooling only, no plugin runtime code changes.
