### PR TITLE
fix: load activation classes for WP-CLI

### DIFF
--- a/super-forms.php
+++ b/super-forms.php
@@ -216,12 +216,12 @@ if(!class_exists('SUPER_Forms')) :
         public function includes(){
             
             include_once( 'includes/class-common.php' );
+            include_once( 'includes/class-install.php' );
+            include_once( 'includes/class-settings.php' );
              
             if ( $this->is_request( 'admin' ) ) {
-                include_once( 'includes/class-install.php' );
                 include_once( 'includes/class-menu.php' );
                 include_once( 'includes/class-pages.php' );
-                include_once( 'includes/class-settings.php' );
                 include_once( 'includes/class-shortcodes.php' );
                 include_once( 'includes/class-field-types.php' );
             }


### PR DESCRIPTION
## Summary

- load activation and settings classes outside the admin-only request path
- restore WP-CLI activation on PHP 8+

## Verification

- PHP 8.3 syntax check passed
- submission-validation runtime suite passed all 6 scenarios against the 6.3.315 worktree
